### PR TITLE
Add more flexibility to tool run

### DIFF
--- a/lib/vancouver/methods/tools_call.ex
+++ b/lib/vancouver/methods/tools_call.ex
@@ -13,7 +13,7 @@ defmodule Vancouver.Methods.ToolsCall do
 
     with {:ok, tool} <- get_tool(tools, name),
          :ok <- validate_arguments(tool, arguments) do
-      call_tool(conn, request, tool, arguments)
+      tool.run(conn, arguments)
     else
       {:error, :not_found} -> tool_not_found(conn, request)
       {:error, {:invalid_params, reason}} -> invalid_params(conn, request, reason)
@@ -34,18 +34,6 @@ defmodule Vancouver.Methods.ToolsCall do
     end
   end
 
-  defp call_tool(conn, request, tool, arguments) do
-    result =
-      case tool.run(conn, arguments) do
-        {:ok, result} -> tool_success_result(result)
-        {:error, reason} -> tool_error_result(reason)
-      end
-
-    response = JsonRpc2.success_response(request["id"], result)
-
-    send_json(conn, response)
-  end
-
   defp tool_not_found(conn, request) do
     data = %{original_request: request}
     response = JsonRpc2.error_response(:method_not_found, request["id"], data)
@@ -59,22 +47,5 @@ defmodule Vancouver.Methods.ToolsCall do
     response = JsonRpc2.error_response(:invalid_params, request_id, data)
 
     send_json(conn, response)
-  end
-
-  def tool_success_result(content), do: tool_result(content, false)
-
-  def tool_error_result(reason), do: tool_result(reason, true)
-
-  def tool_result(content, is_error \\ false) do
-    text_content =
-      case content do
-        content when is_binary(content) -> content
-        _ -> JSON.encode!(content)
-      end
-
-    %{
-      "content" => [%{type: "text", text: text_content}],
-      "isError" => is_error
-    }
   end
 end

--- a/lib/vancouver/methods/tools_call.ex
+++ b/lib/vancouver/methods/tools_call.ex
@@ -36,7 +36,7 @@ defmodule Vancouver.Methods.ToolsCall do
 
   defp call_tool(conn, request, tool, arguments) do
     result =
-      case tool.run(arguments) do
+      case tool.run(conn, arguments) do
         {:ok, result} -> tool_success_result(result)
         {:error, reason} -> tool_error_result(reason)
       end

--- a/lib/vancouver/tool.ex
+++ b/lib/vancouver/tool.ex
@@ -23,7 +23,7 @@ defmodule Vancouver.Tool do
 
   Should return {:ok, result} on success or {:error, message} on failure.
   """
-  @callback run(params :: map()) :: {:ok, any()} | {:error, String.t()}
+  @callback run(conn :: Plug.Conn.t(), params :: map()) :: {:ok, any()} | {:error, String.t()}
 
   defmacro __using__(_opts) do
     quote do

--- a/lib/vancouver/tools/example_tool.ex
+++ b/lib/vancouver/tools/example_tool.ex
@@ -23,7 +23,7 @@ defmodule Vancouver.Tools.ExampleTool do
     }
   end
 
-  def run(%{"example_param" => example_param}) do
+  def run(_conn, %{"example_param" => example_param}) do
     {:ok, "Example tool executed successfully with param: #{example_param}"}
   end
 end

--- a/lib/vancouver/tools/example_tool.ex
+++ b/lib/vancouver/tools/example_tool.ex
@@ -23,7 +23,7 @@ defmodule Vancouver.Tools.ExampleTool do
     }
   end
 
-  def run(_conn, %{"example_param" => example_param}) do
-    {:ok, "Example tool executed successfully with param: #{example_param}"}
+  def run(conn, %{"example_param" => example_param}) do
+    send_text(conn, "Executing example tool with param: #{example_param}")
   end
 end


### PR DESCRIPTION
For more general usage, we should:

- expose the connection to tools so they can access assigns etc
- let tools return a connection, so they can have freedom in how they respond to incoming requests
- provide helpers to simplify returning a valid mcp response from tools