### PR TITLE
Add CI badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![CI](https://github.com/jameslong/vancouver/actions/workflows/test.yml/badge.svg)](https://github.com/jameslong/vancouver/actions/workflows/test.yml)
 [![Hex.pm](https://img.shields.io/hexpm/v/vancouver.svg)](https://hex.pm/packages/vancouver)
 [![Hexdocs.pm](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/vancouver/)
 [![Hex.pm](https://img.shields.io/hexpm/dt/vancouver.svg)](https://hex.pm/packages/vancouver)


### PR DESCRIPTION
This pull request updates the `README.md` file to include a CI status badge, providing visibility into the current build and test status of the project.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1): Added a CI status badge linking to the GitHub Actions workflow for testing (`test.yml`).