### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,29 @@
 # Changelog
 
-## [0.1.1](https://github.com/jameslong/vancouver) - 2025-05-30
+## v0.2.0 (2025-06-12)
+
+### Breaking changes
+
+- Tools must now be passed as an option to `Vancouver.Router` rather than defined in the config
+
+i.e. 
+
+```elixir
+# v0.1.1
+config :vancouver,
+  ...
+  tools: [MyApp.Tools.CalculateSum]
+
+# v0.2.0
+forward "/mcp", Vancouver.Router, tools: [MyApp.Tools.CalculateSum]
+```
+
+### Features
+- helpers to send audio/image responses (#6)
+- `Vancouver.ToolTest` (#7)
+
+
+## v0.1.1 (2025-05-30)
 
 ### Added
 - docs! (#3)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ In `mix.exs`:
 ```elixir
 defp deps do
   [
-    {:vancouver, "~> 0.1"}
+    {:vancouver, "~> 0.2"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vancouver.MixProject do
   def project do
     [
       app: :vancouver,
-      version: "0.1.1",
+      version: "0.2.0",
       elixir: "~> 1.18",
       description: description(),
       package: package(),


### PR DESCRIPTION
This pull request updates the Vancouver library to version 0.2.0, introducing breaking changes, new features, and version updates in the documentation and configuration files.

### Breaking Changes:
* Tools must now be passed as an option to `Vancouver.Router` instead of being defined in the configuration. This requires updates to how tools are specified in the codebase. (`CHANGELOG.md`: [CHANGELOG.mdL3-R26](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL3-R26))

### New Features:
* Added helpers for sending audio and image responses. (`CHANGELOG.md`: [CHANGELOG.mdL3-R26](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL3-R26))
* Introduced `Vancouver.ToolTest` for testing tools. (`CHANGELOG.md`: [CHANGELOG.mdL3-R26](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL3-R26))

### Version Updates:
* Updated the library version in `mix.exs` from `0.1.1` to `0.2.0`. (`mix.exs`: [mix.exsL7-R7](diffhunk://#diff-dfa6f4ed74c90e5d4fda283d547d366586e690387289bcfd473e3fa5f9ace308L7-R7))
* Updated the dependency version in the `README.md` file from `~> 0.1` to `~> 0.2`. (`README.md`: [README.mdL20-R20](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L20-R20))