### PR TITLE
Add PromptTest

### DIFF
--- a/lib/vancouver/test/prompt_test.ex
+++ b/lib/vancouver/test/prompt_test.ex
@@ -13,7 +13,7 @@ defmodule Vancouver.PromptTest do
       assert content["mimeType"] == "audio/wav"
 
   """
-  @spec audio_response(Plug.Conn.t()) :: %{data: String.t(), mimeType: String.t()}
+  @spec audio_response(Plug.Conn.t()) :: map()
   def audio_response(conn) do
     response = JSON.decode!(conn.resp_body)
 
@@ -73,7 +73,7 @@ defmodule Vancouver.PromptTest do
       assert content["mimeType"] == "image/png"
 
   """
-  @spec image_response(Plug.Conn.t()) :: %{data: String.t(), mimeType: String.t()}
+  @spec image_response(Plug.Conn.t()) :: map()
   def image_response(conn) do
     response = JSON.decode!(conn.resp_body)
 

--- a/lib/vancouver/test/tool_test.ex
+++ b/lib/vancouver/test/tool_test.ex
@@ -34,7 +34,7 @@ defmodule Vancouver.ToolTest do
       assert content["mimeType"] == "audio/wav"
 
   """
-  @spec audio_response(Plug.Conn.t()) :: %{data: String.t(), mimeType: String.t()}
+  @spec audio_response(Plug.Conn.t()) :: map()
   def audio_response(conn) do
     response = JSON.decode!(conn.resp_body)
 
@@ -72,7 +72,7 @@ defmodule Vancouver.ToolTest do
       assert content["mimeType"] == "image/png"
 
   """
-  @spec image_response(Plug.Conn.t()) :: %{data: String.t(), mimeType: String.t()}
+  @spec image_response(Plug.Conn.t()) :: map()
   def image_response(conn) do
     response = JSON.decode!(conn.resp_body)
 

--- a/test/vancouver/test/prompt_test.exs
+++ b/test/vancouver/test/prompt_test.exs
@@ -7,7 +7,7 @@ defmodule Vancouver.Test.PromptTest do
   alias Vancouver.JsonRpc2
   alias Vancouver.PromptTest
 
-  describe "build_request/3" do
+  describe "build_request/2" do
     test "creates a valid get request" do
       prompt_name = "test_prompt"
       arguments = %{"arg1" => "value1", "arg2" => "value2"}


### PR DESCRIPTION
This pull request introduces a new module, `Vancouver.PromptTest`, to provide utility functions for testing prompts, along with a comprehensive test suite in `Vancouver.Test.PromptTest` to validate these utilities. The changes aim to streamline the testing of responses for different content types (audio, image, text) and ensure robust handling of various scenarios.

### New Testing Utilities:
* Added `Vancouver.PromptTest` module with functions to process and validate responses (`audio_response/1`, `image_response/1`, `text_response/1`), build request bodies (`build_request/2`), and extract roles (`get_role/1`). These utilities simplify testing by encapsulating common logic.

### Test Suite for Utilities:
* Introduced `Vancouver.Test.PromptTest` with unit tests for each utility function:
  - Validated correct behavior for `audio_response/1`, `image_response/1`, and `text_response/1` with valid and invalid inputs.
  - Tested `build_request/2` to ensure it generates properly formatted request payloads.