### PR TITLE
Add test helper functions and update test files

### DIFF
--- a/lib/vancouver/test/prompt_test.ex
+++ b/lib/vancouver/test/prompt_test.ex
@@ -27,11 +27,11 @@ defmodule Vancouver.PromptTest do
 
   ## Examples
 
-      body = build_request("code_review", %{"code" => "def hello, do: \"Hello, World!\""})
+      body = build_get_request("code_review", %{"code" => "def hello, do: \"Hello, World!\""})
 
   """
-  @spec build_request(String.t(), map()) :: map()
-  def build_request(prompt_name, arguments) do
+  @spec build_get_request(String.t(), map()) :: map()
+  def build_get_request(prompt_name, arguments) do
     %{
       "jsonrpc" => "2.0",
       "id" => 1,

--- a/lib/vancouver/test/tool_test.ex
+++ b/lib/vancouver/test/tool_test.ex
@@ -4,27 +4,6 @@ defmodule Vancouver.ToolTest do
   """
 
   @doc """
-  Creates a valid request body for a tool call request.
-
-  ## Examples
-
-      body = call_request("calculate_sum", %{"a" => 1, "b" => 2})
-
-  """
-  @spec call_request(String.t(), map()) :: map()
-  def call_request(tool_name, arguments) do
-    %{
-      "jsonrpc" => "2.0",
-      "id" => 1,
-      "method" => "tools/call",
-      "params" => %{
-        "name" => tool_name,
-        "arguments" => arguments
-      }
-    }
-  end
-
-  @doc """
   Asserts that the response was successful, and that audio content was returned.
 
   ## Examples
@@ -42,6 +21,27 @@ defmodule Vancouver.ToolTest do
     |> check_success()
     |> check_type("audio")
     |> get_content()
+  end
+
+  @doc """
+  Creates a valid request body for a tool call request.
+
+  ## Examples
+
+      body = build_call_request("calculate_sum", %{"a" => 1, "b" => 2})
+
+  """
+  @spec build_call_request(String.t(), map()) :: map()
+  def build_call_request(tool_name, arguments) do
+    %{
+      "jsonrpc" => "2.0",
+      "id" => 1,
+      "method" => "tools/call",
+      "params" => %{
+        "name" => tool_name,
+        "arguments" => arguments
+      }
+    }
   end
 
   @doc """

--- a/test/vancouver/test/prompt_test.exs
+++ b/test/vancouver/test/prompt_test.exs
@@ -7,12 +7,12 @@ defmodule Vancouver.Test.PromptTest do
   alias Vancouver.JsonRpc2
   alias Vancouver.PromptTest
 
-  describe "build_request/2" do
+  describe "build_get_request/2" do
     test "creates a valid get request" do
       prompt_name = "test_prompt"
       arguments = %{"arg1" => "value1", "arg2" => "value2"}
 
-      assert PromptTest.build_request(prompt_name, arguments) == %{
+      assert PromptTest.build_get_request(prompt_name, arguments) == %{
                "jsonrpc" => "2.0",
                "id" => 1,
                "method" => "prompts/get",

--- a/test/vancouver/test/tool_test.exs
+++ b/test/vancouver/test/tool_test.exs
@@ -7,12 +7,12 @@ defmodule Vancouver.Test.ToolTest do
   alias Vancouver.JsonRpc2
   alias Vancouver.ToolTest
 
-  describe "call_request/3" do
+  describe "build_call_request/2" do
     test "creates a valid call request" do
       tool_name = "test_tool"
       arguments = %{"arg1" => "value1", "arg2" => "value2"}
 
-      assert ToolTest.call_request(tool_name, arguments) == %{
+      assert ToolTest.build_call_request(tool_name, arguments) == %{
                "jsonrpc" => "2.0",
                "id" => 1,
                "method" => "tools/call",

--- a/test/vancouver/tools/calculate_sum_test.exs
+++ b/test/vancouver/tools/calculate_sum_test.exs
@@ -16,7 +16,7 @@ defmodule Vancouver.Tools.CalculateSumTest do
   end
 
   defp build_conn(tool_name, tool_arguments) do
-    body = ToolTest.call_request(tool_name, tool_arguments)
+    body = ToolTest.build_call_request(tool_name, tool_arguments)
 
     :post
     |> conn("/", JSON.encode!(body))

--- a/test/vancouver/tools/test_response_test.exs
+++ b/test/vancouver/tools/test_response_test.exs
@@ -42,7 +42,7 @@ defmodule Vancouver.Tools.TestResponseTest do
   end
 
   defp build_conn(tool_name, tool_arguments) do
-    body = ToolTest.call_request(tool_name, tool_arguments)
+    body = ToolTest.build_call_request(tool_name, tool_arguments)
 
     :post
     |> conn("/", JSON.encode!(body))


### PR DESCRIPTION
This pull request refactors request-building functions in the Vancouver codebase to improve naming consistency and clarity. The changes include renaming methods and updating their references across the codebase.

### Refactoring of request-building functions:

* Renamed `build_request/2` to `build_get_request/2` in `lib/vancouver/test/prompt_test.ex` and updated its references in `test/vancouver/test/prompt_test.exs` to reflect the new name. [[1]](diffhunk://#diff-b22921b0a9f6e58cab606c424ab10a28907f5880768f99c749cd144b213254e8L30-R34) [[2]](diffhunk://#diff-d304e3e8109aaec085e9272262645e0495e492402277a8f5778a28a700b59263L10-R15)
* Renamed `call_request/2` to `build_call_request/2` in `lib/vancouver/test/tool_test.ex` and updated its references in `test/vancouver/test/tool_test.exs`, `test/vancouver/tools/calculate_sum_test.exs`, and `test/vancouver/tools/test_response_test.exs`. [[1]](diffhunk://#diff-46f1f8dd0367635013e2a960e8b443f04851860b6646496807f55197bb6ebbfeL6-L26) [[2]](diffhunk://#diff-46f1f8dd0367635013e2a960e8b443f04851860b6646496807f55197bb6ebbfeR26-R46) [[3]](diffhunk://#diff-53639dd4a2c27ceec16ac03497d8706e88314f8904b83e34289d4579f246b060L10-R15) [[4]](diffhunk://#diff-200e653fe6acc18f2409e4682a05e566e4997831e63af9d366306ab57459f10fL19-R19) [[5]](diffhunk://#diff-3da77c931267b328d65fee80b38a8d16ebc87af82d874b2219a2ece98d53f9bcL45-R45)