### PR TITLE
V0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,30 +1,55 @@
 # Changelog
 
-## v0.2.0 (2025-06-12)
-
-### Breaking changes
-
-- Tools must now be passed as an option to `Vancouver.Router` rather than defined in the config
-
-i.e. 
-
-```elixir
-# v0.1.1
-config :vancouver,
-  ...
-  tools: [MyApp.Tools.CalculateSum]
-
-# v0.2.0
-forward "/mcp", Vancouver.Router, tools: [MyApp.Tools.CalculateSum]
-```
-
-### Features
-- helpers to send audio/image responses (#6)
-- `Vancouver.ToolTest` (#7)
-
-
-## v0.1.1 (2025-05-30)
+## [v0.3.0] - 2025-06-17
 
 ### Added
-- docs! (#3)
-- easier integration with Phoenix router via `Vancouver.Router` (#4)
+- **Prompts Support**: Adds support for MCP prompts, including `Vancouver.PromptTest` for easier testing (#13, #14)
+- **Router Integration**: Prompts can now be configured as options in `Vancouver.Router` (#13)
+
+  ```elixir
+  forward "/mcp", Vancouver.Router, 
+    tools: [MyApp.Tools.CalculateSum],
+    prompts: [MyApp.Prompts.CodeReview]
+  ```
+
+### Changed
+- **Test Helper Rename**: `Vancouver.ToolTest.call_request/2` has been renamed to `Vancouver.ToolTest.build_call_request/2`
+
+### Migration Guide
+Update your test files to use the new function name:
+
+```elixir
+# Before (v0.2.x)
+request = Vancouver.ToolTest.call_request(tool_name, arguments)
+
+# After (v0.3.0+)
+request = Vancouver.ToolTest.build_call_request(tool_name, arguments)
+```
+
+## [v0.2.0](https://github.com/your-repo/vancouver/releases/tag/v0.2.0) - 2025-06-12
+
+### Breaking Changes
+- **Tool Configuration**: Tools must now be passed as options to `Vancouver.Router` instead of being defined in application config
+
+  **Before (v0.1.x):**
+  ```elixir
+  # config/config.exs
+  config :vancouver,
+    tools: [MyApp.Tools.CalculateSum]
+  ```
+
+  **After (v0.2.0+):**
+  ```elixir
+  # router.ex
+  forward "/mcp", Vancouver.Router, tools: [MyApp.Tools.CalculateSum]
+  ```
+
+### Added
+- **Media Response Helpers**: New utilities for sending audio and image responses (#6)
+- **Testing Support**: Introduction of `Vancouver.ToolTest` for easier tool testing (#7)
+
+## [v0.1.1](https://github.com/your-repo/vancouver/releases/tag/v0.1.1) - 2025-05-30
+
+### Added
+- **Documentation**: Comprehensive documentation and guides (#3)
+- **Phoenix Integration**: Streamlined integration with Phoenix router via `Vancouver.Router` (#4)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [v0.3.0] - 2025-06-17
+## v0.3.0 - 2025-06-17
 
 ### Added
 - **Prompts Support**: Adds support for MCP prompts, including `Vancouver.PromptTest` for easier testing (#13, #14)
@@ -26,7 +26,7 @@ request = Vancouver.ToolTest.call_request(tool_name, arguments)
 request = Vancouver.ToolTest.build_call_request(tool_name, arguments)
 ```
 
-## [v0.2.0](https://github.com/your-repo/vancouver/releases/tag/v0.2.0) - 2025-06-12
+## v0.2.0 - 2025-06-12
 
 ### Breaking Changes
 - **Tool Configuration**: Tools must now be passed as options to `Vancouver.Router` instead of being defined in application config
@@ -48,7 +48,7 @@ request = Vancouver.ToolTest.build_call_request(tool_name, arguments)
 - **Media Response Helpers**: New utilities for sending audio and image responses (#6)
 - **Testing Support**: Introduction of `Vancouver.ToolTest` for easier tool testing (#7)
 
-## [v0.1.1](https://github.com/your-repo/vancouver/releases/tag/v0.1.1) - 2025-05-30
+## v0.1.1 - 2025-05-30
 
 ### Added
 - **Documentation**: Comprehensive documentation and guides (#3)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # Vancouver
 
-Vancouver makes it easy to add [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) functionality to your Phoenix/Bandit server. Vancouver handles initialization, request validation, and offers helper functions to simplify the creation of MCP tools. 
+Vancouver makes it easy to add [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) functionality to your Phoenix/Bandit server. Vancouver handles initialization, request validation, and offers helper functions to simplify the creation of MCP tools and prompts. 
 
 ## Getting started
 
@@ -17,12 +17,14 @@ In `mix.exs`:
 ```elixir
 defp deps do
   [
-    {:vancouver, "~> 0.2"}
+    {:vancouver, "~> 0.3"}
   ]
 end
 ```
 
-### 2. Create your tools
+### 2. Create your tools/prompts
+
+You can implement tools like this:
 
 ```elixir
 defmodule MyApp.Tools.CalculateSum do
@@ -48,6 +50,32 @@ defmodule MyApp.Tools.CalculateSum do
 end
 ```
 
+And prompts like this:
+
+```elixir
+defmodule MyApp.Prompts.CodeReview do
+  use Vancouver.Prompt
+
+  def name, do: "code_review"
+  def description, do: "Asks the LLM to analyze code quality and suggest improvements"
+
+  def arguments do
+    [
+      %{
+        "name" => "code",
+        "description" => "The code to review",
+        "required" => true
+      }
+    ]
+  end
+
+  def run(conn, %{"code" => code}) do
+    send_text(conn, "Please review this code: #{code}")
+  end
+end
+```
+
+
 ### 3. Add config
 
 In `config.ex`:
@@ -63,7 +91,9 @@ config :vancouver,
 In `router.ex`:
 
 ```elixir
-forward "/mcp", Vancouver.Router, tools: [MyApp.Tools.CalculateSum]
+forward "/mcp", Vancouver.Router, 
+  tools: [MyApp.Tools.CalculateSum],
+  prompts: [MyApp.Prompts.CodeReview]
 ```
 
 ### 5. (Optional) Add to your MCP client
@@ -90,10 +120,9 @@ Run your server, and restart Claude to starting using your MCP tools. 🚀
 
 Not yet. Vancouver currently supports:
 
-- streamable HTTP transport
 - tools
+- prompts
 - sync responses (no streaming)
-- single messages (no batching)
 
 However, the library is simple enough that you should be able to modify it for your needs.
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vancouver.MixProject do
   def project do
     [
       app: :vancouver,
-      version: "0.2.0",
+      version: "0.3.0",
       elixir: "~> 1.18",
       description: description(),
       package: package(),


### PR DESCRIPTION
This pull request introduces version `0.3.0` of the Vancouver library, adding significant new features, updates, and documentation improvements. The key changes include support for MCP prompts, updates to the test helper function, and enhancements to the README for better onboarding.

### New Features and Enhancements:
* **Prompts Support**: Added support for MCP prompts, including a new example module `MyApp.Prompts.CodeReview` for creating prompts. Prompts can now be configured alongside tools in `Vancouver.Router`. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL3-R55) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R53-R78) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L66-R96)
* **Documentation Updates**: Improved the README to include instructions for creating and configuring prompts, updating the dependency to version `0.3.0`, and clarifying supported features. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L9-R9) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L20-R27) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L93-L96)

### Breaking Changes:
* **Test Helper Rename**: Renamed `Vancouver.ToolTest.call_request/2` to `Vancouver.ToolTest.build_call_request/2`, requiring updates to test files.

### Version Update:
* **Version Bump**: Updated the library version from `0.2.0` to `0.3.0` in `mix.exs`.